### PR TITLE
Add config.py + Remove pysrvx submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ etc/config.yaml
 __pycache__
 db/*.db
 !db/.keep
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+etc/config.py
 etc/config.yaml
 __pycache__
 pysrvx-git

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ etc/config.py
 etc/config.yaml
 __pycache__
 pysrvx-git
-etc/config.yaml
 db/*.db
 !db/.keep

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 etc/config.py
 etc/config.yaml
 __pycache__
-pysrvx-git
 db/*.db
 !db/.keep

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pysrvx-git"]
-	path = pysrvx-git
-	url = https://github.com/GameSurge/pysrvx

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Initial setup
+
+ 1. Install packages:
+
+    ~~~sh
+    sudo apt-get install virtualenv
+    ~~~
+
+ 2. Create a Python environment:
+
+    ~~~sh
+    virtualenv -p python3 venv
+    ~~~
+
+ 3. Activate the environment for the current shell session:
+
+    ~~~sh
+    . venv/bin/activate
+    ~~~
+
+    **It is necessary to repeat this command later on if the shell session is
+    closed or deactivated.**
+
+ 4. Install dependencies:
+
+    ~~~sh
+    pip install -r requirements.txt
+    ~~~
+
+# Configuration
+
+There are two separate configuration files:
+
+  - `etc/config.py` for server and database configuration
+  - `etc/config.yaml` for pysrvx configuration
+
+Examples are found in the `etc` directory.
+
+# Running the development server
+
+ 1. Activate the Python environment if necessary (see section "Initial setup").
+
+ 2. Run the server as a module:
+
+    ~~~sh
+    FLASK_APP=main.py flask run --debugger -h 127.0.0.1 -p 8080
+    ~~~

--- a/etc/config.py.example
+++ b/etc/config.py.example
@@ -1,0 +1,7 @@
+# A random secret that is used for session management.  To use an environment
+# variable, first `import os` and then do
+# `SECRET_KEY = os.environ['MY_SECRET_KEY']`.  See also:
+# http://flask.pocoo.org/docs/0.11/api/#flask.Flask.secret_key
+SECRET_KEY = 'sadfkjhdfsajhfdsakjlhfd'
+
+SQLALCHEMY_DATABASE_URI = 'sqlite:///./db/test.db'

--- a/gamesurge/decorators.py
+++ b/gamesurge/decorators.py
@@ -1,4 +1,5 @@
 import pysrvx.srvx
+import sys
 import traceback
 
 from flask import g
@@ -31,7 +32,7 @@ def requiresrvx(app):
                     pysrvx.srvx.QServerSecurityViolation):
                 return("Services are currently unavailable")
             except Exception as e:
-                print("Error processing {}: <pre>{}</pre>".format(func.__name__, traceback.format_exc()))
+                print("Error processing {}: <pre>{}</pre>".format(func.__name__, traceback.format_exc()), file=sys.stderr, flush=True)
                 return("An error has occured, please try again later")
         return modified_func
     return decorator

--- a/gamesurge/utils.py
+++ b/gamesurge/utils.py
@@ -1,4 +1,5 @@
 import pysrvx.srvx
+import sys
 
 from flask import g
 
@@ -38,6 +39,6 @@ class Services:
                 c['authserv_password'],
                 c['bind'])
         except pysrvx.srvx.AuthenticationError as e:
-            print("Unable to connect to SrvX {}".format(e))
+            print("Unable to connect to SrvX {}".format(e), file=sys.stderr, flush=True)
         except pysrvx.srvx.ConnectionError as e:
-            print("No SrvX connection found {}".format(e))
+            print("No SrvX connection found {}".format(e), file=sys.stderr, flush=True)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3.5
 import flask_login
+import sys
 import traceback
 import yaml
 
@@ -22,15 +23,15 @@ def check_config():
     try:
         app.config['GS_CONF'] = yaml.load(open('./etc/config.yaml', 'r'))
     except yaml.YAMLError:
-        print("Error reading YAML file: {}".format(traceback.format_exc()))
-        exit()
+        print("Error reading YAML file: {}".format(traceback.format_exc()), file=sys.stderr, flush=True)
+        exit(1)
     except FileNotFoundError:
-        print("You must setup your config file in \"etc/config.yaml\"")
-        exit()
+        print('You must setup your config file in "etc/config.yaml"', file=sys.stderr, flush=True)
+        exit(1)
 
     if 'qserver' not in app.config['GS_CONF']:
-        print("You must supply a valid config file.")
-        exit()
+        print("You must supply a valid config file.", file=sys.stderr, flush=True)
+        exit(1)
 
 @app.route('/index')
 @app.route('/')

--- a/main.py
+++ b/main.py
@@ -9,11 +9,8 @@ from flask import Flask, flash, render_template, request, g
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///./db/test.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
-""" TODO: OS Variable """
-app.config['SECRET_KEY'] = 'sadfkjhdfsajhfdsakjlhfd'
+app.config.from_pyfile('etc/config.py')
 app.config['GS_CONF'] = None
 db = SQLAlchemy(app)
 

--- a/pysrvx
+++ b/pysrvx
@@ -1,1 +1,0 @@
-pysrvx-git/pysrvx/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==0.11.1
 Flask-SQLAlchemy==2.1
 PyYAML==3.12
 flask-login==0.3.2
+-e git+https://github.com/GameSurge/pysrvx.git@29e4749c21214d9994edc6d9a64ab815b0e483b4#egg=pysrvx


### PR DESCRIPTION
- Allow `SECRET_KEY` and `SQLALCHEMY_DATABASE_URI` to be configured using `etc/config.py`.
- Remove the `pysrvx` submodule in favor of installing the dependencies via `pip`.
- Add instructions for how to set up and run the server using [`virtualenv`](https://virtualenv.pypa.io).
- Some other miscellaneous cleanup.

I didn't want to touch `config.yaml` in this PR, but maybe it'd be a good idea also merge `config.py` and `config.yaml` in the future?
